### PR TITLE
Remove az CLI References from Script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,6 @@ COPY --chown=developer:developer modules/vim-autoload /home/developer/.local/sha
 COPY --chown=developer:developer modules/neovim-plug/plug.vimrc /home/developer/.modules/neovim-plug/plug.vimrc
 RUN pwsh -c '/home/developer/neovim/bin/nvim -n -u /home/developer/.modules/neovim-plug/plug.vimrc -i NONE +"PlugInstall" +"qa"' || pwsh -c '/home/developer/neovim/bin/nvim -n -u /home/developer/.modules/neovim-plug/plug.vimrc -i NONE +"PlugInstall" +"qa"' 
 
-# Azure-CLI extensions installation
-COPY --chown=developer:developer modules/azure-cli-extensions /home/developer/.modules/azure-cli-extensions
-RUN export PATH="$HOME/.local/bin:$PATH" && pipx install azure-cli && chmod +x /home/developer/.modules/azure-cli-extensions/azure-extensions-setup.sh && /home/developer/.modules/azure-cli-extensions/azure-extensions-setup.sh
-
 # Delta diff installation
 COPY --chown=developer:developer modules/git /home/developer/.modules/git
 RUN pwsh -NoProfile -File /home/developer/.modules/git/delta-setup.ps1


### PR DESCRIPTION
Removed the Azure CLI installation step from the Dockerfile, which includes:
- pipx install azure-cli
- azure-cli-extensions setup

This significantly reduces the container size while keeping the Azure CLI module files available for host installation if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)